### PR TITLE
chore: bump packaged elm-review version

### DIFF
--- a/elm.novaextension/npm-shrinkwrap.json
+++ b/elm.novaextension/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
         "@elm-tooling/elm-language-server": "^2.3.0",
         "elm": "^0.19.1-5",
         "elm-format": "^0.8.5",
-        "elm-review": "^2.6.1",
+        "elm-review": "^2.7.0",
         "elm-test": "^0.19.1-revision7"
       }
     },
@@ -703,14 +703,14 @@
       }
     },
     "node_modules/elm-review": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.6.1.tgz",
-      "integrity": "sha512-sWkHt1DMXkRyPqhMAIym4+5OVJHUmexvrYY5cdVkKr9Qdw+6ND1wH6V1ACu4vge3YdonG7UC+6gCYeHkgI760g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.7.0.tgz",
+      "integrity": "sha512-PvZj6M6rHYpyAGp2MKF/TzeDawioQacBTkVxzlBBGuMoO4LXw2PMIm/NmhkxcD38l5SvDIwpWmyDKvEsMaWNhQ==",
       "dependencies": {
         "chalk": "^4.0.0",
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
-        "elm-tooling": "^1.4.1",
+        "elm-tooling": "^1.6.0",
         "fast-levenshtein": "^3.0.0",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",
@@ -2885,14 +2885,14 @@
       }
     },
     "elm-review": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.6.1.tgz",
-      "integrity": "sha512-sWkHt1DMXkRyPqhMAIym4+5OVJHUmexvrYY5cdVkKr9Qdw+6ND1wH6V1ACu4vge3YdonG7UC+6gCYeHkgI760g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/elm-review/-/elm-review-2.7.0.tgz",
+      "integrity": "sha512-PvZj6M6rHYpyAGp2MKF/TzeDawioQacBTkVxzlBBGuMoO4LXw2PMIm/NmhkxcD38l5SvDIwpWmyDKvEsMaWNhQ==",
       "requires": {
         "chalk": "^4.0.0",
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.5.2",
         "cross-spawn": "^7.0.3",
-        "elm-tooling": "^1.4.1",
+        "elm-tooling": "^1.6.0",
         "fast-levenshtein": "^3.0.0",
         "find-up": "^4.1.0",
         "folder-hash": "^3.3.0",

--- a/elm.novaextension/package.json
+++ b/elm.novaextension/package.json
@@ -5,7 +5,7 @@
     "@elm-tooling/elm-language-server": "^2.3.0",
     "elm": "^0.19.1-5",
     "elm-format": "^0.8.5",
-    "elm-review": "^2.6.1",
+    "elm-review": "^2.7.0",
     "elm-test": "^0.19.1-revision7"
   }
 }


### PR DESCRIPTION
Bump `elm-review` version from `2.6.1` to `2.7.0`